### PR TITLE
fix:创建项目中选择zap,build出现cannot call non-function di.ZapOutput{...……} (type di.ZapOutput)

### DIFF
--- a/src/mixcli/commands/new.go
+++ b/src/mixcli/commands/new.go
@@ -218,7 +218,7 @@ func (t *NewCommand) NewProject(name, selectType, useDotenv, useConf, selectLog,
 		if err := logic.ReplaceAll(dest, `logger := di.Logrus`, `logger := di.Zap`); err != nil {
 			panic(errors.New("Replace failed"))
 		}
-		if err := logic.ReplaceAll(dest, `Output: logger.Writer()`, `Output: &di.ZapOutput{Logger: logger}`); err != nil {
+		if err := logic.ReplaceAll(dest, `Output: logger.Writer\(\)`, `Output: &di.ZapOutput{Logger: logger}`); err != nil {
 			panic(errors.New("Replace failed"))
 		}
 		_ = os.Remove(fmt.Sprintf("%s/di/logrus.go", dest))


### PR DESCRIPTION
fix:修复命令行创建项目中选择zap,构建项目时出现 cannot call non-function di.ZapOutput{...……} (type di.ZapOutput)